### PR TITLE
JSON Data Handling and Group Deletion

### DIFF
--- a/src/Group/Group.java
+++ b/src/Group/Group.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import Group.MembershipManager.MembershipRequestManager;
 import Group.MembershipManager.MembershipRequestStatus;
 import backend.CurrentUser;
+import backend.Database;
 import backend.User;
 import content.Post;
 
@@ -223,5 +224,23 @@ public class Group {
 
     public String getGroupId() {
         return groupId;
+    }
+
+    public void delete() {
+        // Make all members leave the group
+        for (User member : members) {
+            member.leaveGroup(this.groupId);
+        }
+        // Make all admins leave the group
+        for (User admin : admins) {
+            admin.leaveGroup(this.groupId);
+        }
+        // Make the primary admin leave the group
+        primaryAdmin.getUser().leaveGroup(this.groupId);
+        try {
+            Database.getInstance().deleteGroup(this.groupId);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/Group/Group.java
+++ b/src/Group/Group.java
@@ -5,12 +5,12 @@ import java.util.ArrayList;
 
 
 import Group.MembershipManager.MembershipRequestManager;
-import Group.MembershipManager.MembershipRequestStatus;
 import backend.CurrentUser;
 import backend.Database;
 import backend.User;
 import content.Post;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import utils.*;
 
@@ -205,13 +205,29 @@ public class Group {
         data.put("description", description);
         data.put("group-photo", groupPhoto.getImagePath());
 
-        // THIS MIGHT NEED TO BE CHANGED AFTER MERGING
         data.put("primary-admin", primaryAdmin.getUser().getUserId());
 
-        // data.put("admins", /*admins*/ );
-        // data.put("members", /*members*/ );
+        loadAdmins(data);
+        loadMembers(data);
+
         data.put("notifications", groupNotifManager.toJSONObject());
         return data;
+    }
+
+    private void loadAdmins(JSONObject data) {
+        JSONArray admins = new JSONArray();
+        for (User user : this.admins) {
+            admins.put(user.getUserId());
+        }
+        data.put("admins", admins);
+    }
+
+    private void loadMembers(JSONObject data) {
+        JSONArray members = new JSONArray();
+        for (User user : this.members) {
+            members.put(user.getUserId());
+        }
+        data.put("members", members);
     }
 
     public MembershipRequestManager getMembershipManager() {

--- a/src/Group/Group.java
+++ b/src/Group/Group.java
@@ -192,11 +192,29 @@ public class Group {
         this.groupPhoto = new Picture((String) data.get("group-photo")); // Takes the path of the image
         this.members.clear();
         this.admins.clear();
-        // TODO: Parse JSON for the following attributes
+
         this.primaryAdmin = new PrimaryAdmin(this, (String) data.get("primary-admin"));
-//        this.admins = new ArrayList<>();
-//        this.members = new ArrayList<>();
+
+        setAdmins(data.getJSONArray("admins"));
+        setMembers(data.getJSONArray("members"));
+
         this.groupNotifManager.setGroupNotifs(data.getJSONObject("notifications"));
+    }
+
+    private void setAdmins(JSONArray admins) throws IOException {
+        for (Object obj : admins) {
+            String userID = (String) obj;
+            User user = Database.getInstance().getUser(userID);
+            this.admins.add(user);
+        }
+    }
+
+    private void setMembers(JSONArray members) throws IOException {
+        for (Object obj : members) {
+            String userID = (String) obj;
+            User user = Database.getInstance().getUser(userID);
+            this.members.add(user);
+        }
     }
 
     public JSONObject getGroupData() throws IOException {

--- a/src/Group/PrimaryAdmin.java
+++ b/src/Group/PrimaryAdmin.java
@@ -26,7 +26,6 @@ public class PrimaryAdmin extends Admin{
     }
 
     public void deleteGroup(){
-        group = null;
+        group.delete();
     }
-
 }

--- a/src/backend/Database.java
+++ b/src/backend/Database.java
@@ -277,4 +277,17 @@ public class Database {
             e.printStackTrace();
         }
     }
+
+    // Delete group with its reference, in case we need it
+    public void deleteGroup(Group group) {
+        deleteGroup(group.getGroupId());
+    }
+
+    public int getNumberOfUsers() {
+        return id_to_user.size();
+    }
+
+    public int getNumberOfGroups() {
+        return id_to_group.size();
+    }
 }

--- a/src/backend/Database.java
+++ b/src/backend/Database.java
@@ -265,4 +265,16 @@ public class Database {
             System.out.println("Database error.");
         }
     }
+
+    public void deleteGroup(String groupId) {
+        id_to_group.remove(groupId);
+        try {
+            writeGroupsIDToFiles(); // Rewrite the groups.json file
+            // The group file won't be deleted, but will be deleted from the groups.json file
+            // TODO: Delete the group file (optional)
+            System.out.println("Group with ID: " + groupId + " deleted successfully");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/backend/User.java
+++ b/src/backend/User.java
@@ -22,6 +22,7 @@ import org.json.*;
 public class User {
     private final FriendManagerC friendManager;
     private final SearchManagerC searchManager;
+//    private final MembershipRequestManager membershipManager;
     private String userId;
     private String email;
     private String username;
@@ -39,6 +40,7 @@ public class User {
     public User() throws IOException {
         this.friendManager = FriendManagerFactory.createFriendManager();
         this.searchManager = new SearchManagerC();
+//        this.membershipManager = new MembershipRequestManager();
         this.profile = new Profile(this, "", "icons/profile-icon.jpeg", "");
         this.contentManager = new ContentManager(this);
         this.notifsManager = new NotificationsManager(this);
@@ -56,6 +58,7 @@ public class User {
         this.online = true;
         this.friendManager = FriendManagerFactory.createFriendManager();
         this.searchManager = new SearchManagerC();
+//        this.membershipManager = new MembershipRequestManager();
         this.profile = new Profile(this,"", "icons/profile-icon.jpeg", "");
         this.contentManager = new ContentManager(this);
         this.notifsManager = new NotificationsManager(this);
@@ -71,6 +74,7 @@ public class User {
         password = credentials.getString("password");
         this.friendManager = FriendManagerFactory.createFriendManager();
         this.searchManager = new SearchManagerC();
+//        this.membershipManager = new MembershipRequestManager();
         this.profile = new Profile(this, "", "icons/profile-icon.jpeg", "");
         this.contentManager = new ContentManager(this);
         this.notifsManager = new NotificationsManager(this);
@@ -307,8 +311,8 @@ public class User {
             friends.put(user.getUserId());
         }
         data.put("friends", friends);
-
     }
+
     public void loadBlocked(JSONObject data){
         JSONArray blocked = new JSONArray();
         for (User user : friendManager.getBlockManager().getBlockedUsers()) {

--- a/src/frontend/Group/GroupPageBuilder.java
+++ b/src/frontend/Group/GroupPageBuilder.java
@@ -83,9 +83,9 @@ public class GroupPageBuilder {
         JButton membershipRequests = new JButton("Review Membership requests");
         membershipRequests.addActionListener(_ -> membershipRequestsActionListeners());
         JButton removeMember = new JButton("Remove Member");
-        removeMember.addActionListener(_ -> removeMemberActionListener());
+//        removeMember.addActionListener(_ -> removeMemberActionListener());
         JButton managePosts = new JButton("Manage Posts");
-        managePosts.addActionListener(_ -> managePostsActionLIsteners());
+//        managePosts.addActionListener(_ -> managePostsActionLIsteners());
         JButton post = new JButton("Post");
         post.addActionListener(_ -> postButtonActionListeners());
         JButton leaveGroup = new JButton("Leave Group");


### PR DESCRIPTION
# Backend Feature: JSON Data Handling and Group Deletion

Now when creating a new group, the members and admins JSON objects will be created, this was commented before it was implemented.

## `PrimaryAdmin.java`
Simply call `this.group.delete()`

## `Group.java`
Simply call `database.delete(this)` after making the primary admin, all members, and admins from the group. The leave method saves the users in database in real-time.

## `Database.java`
Simply remove the group from the list and then overwrite the `groups.json` file, this **does not** remove its own file from the groups directory.

## JSON Data Handling in `Group.java`:
Fully implement `setGroupData(JSONObject)` and `getGroupData()`

## Testing
I tested the primary admin's method `deleteGroup()` after manually adding 4 users as admins and members in the JSON files. When the group was deleted, it got removed from the `groups.json` and the group was removed in each user's file.

## Future suggestions:
The group's ID is removed from the `groups.json` file, but it's not deleted from the groups directory, this does not affect the performance at all, although this can be a feature of not permanently deleting the group from the database, as the `groups.json` only marks the current undeleted groups and the groups directory contains all groups whether deleted or not, a restore group feature can be created. (We don't really care but it's a feature that can be easily added because of this)